### PR TITLE
ux tweaks for 109

### DIFF
--- a/web/frontend/components/ProductCard.jsx
+++ b/web/frontend/components/ProductCard.jsx
@@ -61,6 +61,7 @@ export function ProductCard({ product }) {
 
   const {
     mutateAsync: updateVariantMappings,
+    status: variantMappingUpdateStatus,
     isFetching: variantMappingsBeingUpdated
   } = useAppMutation({
     reactQueryOptions: {
@@ -84,6 +85,7 @@ export function ProductCard({ product }) {
   };
 
   const isFdcProduct = product.tags?.includes('fdc');
+  const hasVariantMapped = !!product.fdcVariants[0];
 
   return (
     <Accordion key={product.id} slotProps={{ transition: { unmountOnExit: true } }}>
@@ -92,10 +94,12 @@ export function ProductCard({ product }) {
           <Typography variant="h6">{product.title}</Typography>
           <Stack spacing="20px" direction="row" alignItems="center">
             <FormControlLabel
+              style={{ pointerEvents: "none" }}
               control={
                 <Checkbox
                   style={{
-                    width: '50px'
+                    width: '50px',
+                    pointerEvents: 'auto'
                   }}
                   disabled={isDisabled || product.fdcVariants.length === 0}
                   checked={isFdcProduct}
@@ -115,8 +119,8 @@ export function ProductCard({ product }) {
                 />
               }
               sx={{
-                '& .MuiFormControlLabel-label.Mui-disabled': {
-                  color: isFdcProduct ? 'green' : 'gray'
+                '& .MuiFormControlLabel-label': {
+                  color: hasVariantMapped && isFdcProduct ? 'green' : isFdcProduct ? 'red !important' : 'gray'
                 }
               }}
               label={isFdcProduct ? 'FDC Product' : 'Not FDC Product'}
@@ -134,7 +138,7 @@ export function ProductCard({ product }) {
               saveVariantMapping={saveVariantMapping}
               product={product}
               variant={product.fdcVariants[0]}
-              loadingInProgress={variantMappingsBeingUpdated || productsLoading}
+              loadingInProgress={variantMappingsBeingUpdated || variantMappingUpdateStatus === 'loading' || productsLoading}
             />
           </Stack>
         </Stack>


### PR DESCRIPTION
Make the FDC product text red when it's been flagged as FDC but no variant mapped.

Bonus tweaks:

Disable buttons when variant is being added/removed (the lack of user feedback when you pressed the button was dodgy).
Clicking the "FDC product" label was toggling the checkbox AND opening the product details accordion. This is weird, it should do one or the other, otherwise people may click it to open the details and accidentally unfdc the product. I changed it so you have to click the checkbox to toggle the product and everywhere else toggles the product expansion.
