### PR TITLE
refactoring aggregation fn, relocating it and adding tests

### DIFF
--- a/web/utils/aggregateLineItems.js
+++ b/web/utils/aggregateLineItems.js
@@ -1,0 +1,45 @@
+export const testProductCancellation = [
+  {
+    title: 'test-product',
+    description: 'no more items required due to cancellation',
+    quantity: 1,
+    price: 0,
+    variant_id: 1
+  }
+];
+
+export const aggregateLineItems = (orderType, lineItems) => {
+  const aggregatedLineItems = lineItems.reduce((acc, lineItem) => {
+    const variantId = Number(lineItem.variant_id);
+
+    const { [variantId]: existingLineItem, ...otherLineItems } = acc;
+
+    if (existingLineItem) {
+      const updatedQuantity =
+        orderType === 'completed'
+          ? Number(existingLineItem.quantity) + Number(lineItem.quantity)
+          : Number(existingLineItem.quantity) - Number(lineItem.quantity);
+
+      if (updatedQuantity === 0) {
+        return otherLineItems;
+      }
+
+      return {
+        ...otherLineItems,
+        [variantId]: { variant_id: variantId, quantity: updatedQuantity }
+      };
+    }
+
+    return {
+      ...otherLineItems,
+      [variantId]: {
+        variant_id: variantId,
+        quantity: Number(lineItem.quantity)
+      }
+    };
+  }, {});
+
+  const updateLineItems = Object.values(aggregatedLineItems);
+
+  return updateLineItems.length > 0 ? updateLineItems : testProductCancellation;
+};

--- a/web/utils/aggregateLineItems.spec.js
+++ b/web/utils/aggregateLineItems.spec.js
@@ -1,0 +1,104 @@
+import {
+  aggregateLineItems,
+  testProductCancellation
+} from './aggregateLineItems.js';
+
+it('should aggregate line items correctly for completed order', () => {
+  const orderType = 'completed';
+  const lineItems = [
+    {
+      variant_id: 44525624557875,
+      quantity: 5
+    },
+    {
+      variant_id: 44525624557875,
+      quantity: 3
+    },
+    {
+      variant_id: 123456789,
+      quantity: 2
+    }
+  ];
+
+  const expectedAggregatedLineItems = [
+    {
+      variant_id: 123456789,
+      quantity: 2
+    },
+    {
+      variant_id: 44525624557875,
+      quantity: 8
+    }
+  ];
+
+  const result = aggregateLineItems(orderType, lineItems);
+  expect(result).toEqual(expectedAggregatedLineItems);
+});
+
+it('should aggregate line items correctly for cancelled order', () => {
+  const orderType = 'cancelled';
+  const lineItems = [
+    {
+      variant_id: 44525624557875,
+      quantity: 5
+    },
+    {
+      variant_id: 44525624557875,
+      quantity: 3
+    },
+    {
+      variant_id: 123456789,
+      quantity: 2
+    },
+    {
+      variant_id: 987654321,
+      quantity: 4
+    },
+    {
+      variant_id: 987654321,
+      quantity: 4
+    }
+  ];
+
+  const expectedAggregatedLineItems = [
+    {
+      variant_id: 123456789,
+      quantity: 2
+    },
+    {
+      variant_id: 44525624557875,
+      quantity: 2
+    }
+  ];
+
+  const result = aggregateLineItems(orderType, lineItems);
+
+  expect(result).toEqual(expectedAggregatedLineItems);
+});
+
+it('should remove line item if quantity is 0', () => {
+  const orderType = 'cancelled';
+  const lineItems = [
+    {
+      variant_id: 44525624557875,
+      quantity: 5
+    },
+    {
+      variant_id: 44525624557875,
+      quantity: 5
+    }
+  ];
+
+  const result = aggregateLineItems(orderType, lineItems);
+
+  expect(result).toEqual(testProductCancellation);
+});
+
+it('should return test product if there are no line items', () => {
+  const orderType = 'cancelled';
+  const lineItems = [];
+
+  const result = aggregateLineItems(orderType, lineItems);
+
+  expect(result).toEqual(testProductCancellation);
+});


### PR DESCRIPTION
relates https://github.com/yalla-coop/food-data-collaboration/issues/157

Main objectives of this PR: 
1. Add test for aggregate line items function that is used for re-calculating the running orders for an active SS
2. refactor the function so that it makes use of immutable objects as suggested by Alex 