### PR TITLE
Ensure api access restricted

### DIFF
--- a/web/fdc-modules/fdc-routers.js
+++ b/web/fdc-modules/fdc-routers.js
@@ -4,10 +4,12 @@ import OrdersModules from './orders/index.js';
 import ProductsModules from './products/index.js';
 import UsersModules from './users/index.js';
 
+import checkUserAccessPermissions from '../middleware/checkUserAccessPermissions.js'
+
 const fdcRouter = Router();
 
-fdcRouter.use('/orders', OrdersModules.Controllers);
-fdcRouter.use('/products', ProductsModules.Controllers);
+fdcRouter.use('/orders', checkUserAccessPermissions, OrdersModules.Controllers);
+fdcRouter.use('/products', checkUserAccessPermissions, ProductsModules.Controllers);
 fdcRouter.use('/hub-users', UsersModules.Controllers);
 
 export default fdcRouter;

--- a/web/fdc-modules/products/controllers/index.js
+++ b/web/fdc-modules/products/controllers/index.js
@@ -1,8 +1,6 @@
 import { Router } from 'express';
 import getProducts from './get-products.js';
 import getProductsByIds from './get-products-by-ids.js';
-import checkUserAccessPermissions from '../../../middleware/checkUserAccessPermissions.js';
-
 import checkOfflineSession from '../../../middleware/checkOfflineSession.js';
 
 const products = Router();
@@ -10,7 +8,6 @@ const products = Router();
 products.post(
   '/',
   checkOfflineSession,
-  checkUserAccessPermissions,
   getProducts
 );
 

--- a/web/middleware/checkUserAccessPermissions.js
+++ b/web/middleware/checkUserAccessPermissions.js
@@ -5,16 +5,24 @@ const clientId = process.env.OIDC_CLIENT_ID;
 const clientSecret = process.env.OIDC_CLIENT_SECRET;
 const issuerURL = process.env.OIDC_ISSUER;
 
+const API_KEY = process.env.PRODUCER_API_KEY;
+
 const checkUserAccessPermissions = async (req, res, next) => {
   const { userId, accessToken } = req.body;
 
-  if (!userId) {
+  if (userId) {
+    await authorise(userId, accessToken, res, next);
+  } else if (bearerToken(req) === API_KEY) {
+    return next();
+  } else {
     return res.status(403).json({
       message: 'User access denied',
       error: 'No user id provided'
     });
   }
+};
 
+async function authorise(userId, accessToken, res, next) {
   const issuer = await Issuer.discover(issuerURL);
 
   const client = new issuer.Client({
@@ -67,6 +75,11 @@ const checkUserAccessPermissions = async (req, res, next) => {
       error: err.message
     });
   }
-};
+}
+
+function bearerToken(req) {
+  const token = req.get('authorization');
+  return token?.split(" ")[1];
+}
 
 export default checkUserAccessPermissions;


### PR DESCRIPTION
Make sure the user middle ware is used on api requests from the hub. If the user is not supplied (because the request is a backend job, aka one from a webhook) accept a secret API key for now, until we have a better approach