### PR TITLE
only allow the order creator to interact with it via the api

### DIFF
--- a/web/database/orders/order_migration.sql
+++ b/web/database/orders/order_migration.sql
@@ -1,0 +1,6 @@
+ALTER TABLE orders ADD "owner_id" integer NOT NULL; 
+
+ALTER TABLE orders 
+ADD CONSTRAINT fk_user 
+FOREIGN KEY (owner_id) 
+REFERENCES users (id);

--- a/web/database/orders/orders.js
+++ b/web/database/orders/orders.js
@@ -1,24 +1,33 @@
-import { pool } from '../connect.js'
+import { pool } from '../connect.js';
 
-export const createDraftOrder = async (draftOrderId) => {
-    const result = await pool.query(`
-            INSERT INTO orders (draft_order_id)
-            VALUES ($1)
+export const createDraftOrder = async (draftOrderId, openIdUserId) => {
+  const result = await pool.query(
+    `
+            INSERT INTO orders (draft_order_id, owner_id)
+            VALUES ($1, (SELECT "id" from users where user_id = $2))
             RETURNING *;
-        `, [draftOrderId]);
-    return result.rows;
+        `,
+    [draftOrderId, openIdUserId]
+  );
+  return result.rows;
 };
 
 export const completeDraftOrder = async (draftOrderId, completedOrderId) => {
-    const result = await pool.query(`
+  const result = await pool.query(
+    `
             UPDATE orders set completed_order_id = $2
             WHERE draft_order_id = $1
             RETURNING *;
-        `, [draftOrderId, completedOrderId]);
-    return result.rows;
+        `,
+    [draftOrderId, completedOrderId]
+  );
+  return result.rows;
 };
 
-export const getOrders = async () => {
-    const result = await pool.query(`SELECT draft_order_id as "draftOrderId", completed_order_id as "completedOrderId" from orders order by draft_order_id`, []);
-    return result.rows;
-}
+export const getOrder = async (draftOrderId, openIdUserId) => {
+  const result = await pool.query(
+    `SELECT draft_order_id as "draftOrderId", completed_order_id as "completedOrderId", owner_id as "ownerId" from orders where draft_order_id = $1 AND owner_id = (select id from users where user_id = $2)`,
+    [draftOrderId, openIdUserId]
+  );
+  return result.rows && result.rows.length === 1 ? result.rows[0] : null;
+};

--- a/web/database/orders/orders.spec.js
+++ b/web/database/orders/orders.spec.js
@@ -1,21 +1,36 @@
 import { pool } from '../connect';
-import {createDraftOrder, completeDraftOrder, getOrders} from './orders'
+import {createDraftOrder, completeDraftOrder, getOrder} from './orders'
 
 describe('orders', () => {
+
+    const openIdUserId = '08fcc438-1eb5-4c63-a8f4-894a3960351d';
+
+    const getOrders = async () => {
+        const result = await pool.query(`SELECT draft_order_id as "draftOrderId", completed_order_id as "completedOrderId", owner_id as "ownerId" from orders order by draft_order_id`, []);
+        return result.rows;
+    }
+
     beforeAll(async () => {
         await pool.query(`truncate table orders restart identity`);
     });
 
     it('Order can be created', async () => {
-        await createDraftOrder(55);
-        await createDraftOrder(56);
+        await createDraftOrder(55, openIdUserId);
+        await createDraftOrder(56, openIdUserId);
         const result = await getOrders();
-        expect(result).toStrictEqual([{draftOrderId: "55", completedOrderId: null}, {draftOrderId: "56", completedOrderId: null}])
+        expect(result).toStrictEqual([{draftOrderId: "55", completedOrderId: null, ownerId: 10}, {draftOrderId: "56", completedOrderId: null, ownerId: 10}])
+    });
+
+    it('Order can be retrieved', async () => {
+        expect(await getOrder(55, openIdUserId)).toStrictEqual({draftOrderId: "55", completedOrderId: null, ownerId: 10})
+        expect(await getOrder(55, 12345)).toStrictEqual(null)
+        expect(await getOrder(99, openIdUserId)).toStrictEqual(null)
     });
 
     it('Order can be completed', async () => {
         await completeDraftOrder(55, 654);
         const result = await getOrders();
-        expect(result).toStrictEqual([{draftOrderId: "55", completedOrderId: "654"}, {draftOrderId: "56", completedOrderId: null}])
+        expect(result).toStrictEqual([{draftOrderId: "55", completedOrderId: "654", ownerId: 10}, {draftOrderId: "56", completedOrderId: null, ownerId: 10}])
     })
 });
+

--- a/web/database/orders/schema.sql
+++ b/web/database/orders/schema.sql
@@ -3,8 +3,12 @@ DROP TABLE IF EXISTS "orders" CASCADE;
 CREATE TABLE IF NOT EXISTS "orders" (
     "draft_order_id" bigint PRIMARY KEY,
     "completed_order_id" bigint NULL,
+    "owner_id" integer NOT NULL,
     "created_at" TIMESTAMP NOT NULL DEFAULT NOW(),
-    "updated_at" TIMESTAMP NOT NULL DEFAULT NOW()
+    "updated_at" TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_user
+      FOREIGN KEY(owner_id) 
+        REFERENCES users(id)
 );
 CREATE TRIGGER set_timestamp BEFORE
 UPDATE ON "orders" FOR EACH ROW EXECUTE PROCEDURE trigger_set_timestamp();

--- a/web/fdc-modules/orders/controllers/create-or-update-order-line.js
+++ b/web/fdc-modules/orders/controllers/create-or-update-order-line.js
@@ -4,11 +4,18 @@ import { extractOrderLine, createDfcOrderLineFromShopify } from '../dfc/dfc-orde
 import { persistLineIdMappings } from './lineItemMappings.js'
 import * as orders from './shopify/orders.js';
 import * as ids from './shopify/ids.js'
-// transaction
+import { getOrder } from '../../../database/orders/orders.js';
+
 const createOrUpdateOrderLine = async (req, res) => {
     try {
         const session = await getSession(`${req.params.EnterpriseName}.myshopify.com`)
         const client = new shopify.api.clients.Graphql({ session });
+
+        const order = await getOrder(req.params.id, req.user.id);
+
+        if(!order) {
+            return res.status(403).send('You do not have permission to act on this order');
+        }
 
         const orderLine = await extractOrderLine(req.body)
 

--- a/web/fdc-modules/orders/controllers/create-order.js
+++ b/web/fdc-modules/orders/controllers/create-order.js
@@ -37,7 +37,7 @@ const createOrder = async (req, res) => {
       shopifyLines
     );
 
-    await createDraftOrder(ids.extract(shopifyDraftOrder.id));
+    await createDraftOrder(ids.extract(shopifyDraftOrder.id), req.user.id);
     await createSalesSession(
       ids.extract(shopifyDraftOrder.id),
       saleSession.getEndDate()

--- a/web/fdc-modules/orders/controllers/get-order-line.js
+++ b/web/fdc-modules/orders/controllers/get-order-line.js
@@ -3,10 +3,18 @@ import getSession from '../../../utils/getShopifySession.js';
 import { createDfcOrderLineFromShopify } from '../dfc/dfc-order.js';
 import { findOrder } from './shopify/orders.js';
 import { getLineItems } from '../../../database/line_items/lineItems.js'
+import { getOrder } from '../../../database/orders/orders.js';
+
 const getOrderLine = async (req, res) => {
     try {
         const session = await getSession(`${req.params.EnterpriseName}.myshopify.com`)
         const client = new shopify.api.clients.Graphql({ session });
+
+        const order = await getOrder(req.params.id, req.user.id);
+
+        if(!order) {
+            return res.status(403).send('You do not have permission to act on this order');
+        }
 
         const { order: shopifyOrder } = await findOrder(client, req.params.id, {});
 

--- a/web/fdc-modules/orders/controllers/get-order-lines.js
+++ b/web/fdc-modules/orders/controllers/get-order-lines.js
@@ -3,10 +3,18 @@ import getSession from '../../../utils/getShopifySession.js';
 import { createDfcOrderLinesFromShopify } from '../dfc/dfc-order.js';
 import { findOrder } from './shopify/orders.js';
 import { getLineItems } from '../../../database/line_items/lineItems.js'
+import { getOrder } from '../../../database/orders/orders.js';
+
 const getOrderLines = async (req, res) => {
     try {
         const session = await getSession(`${req.params.EnterpriseName}.myshopify.com`)
         const client = new shopify.api.clients.Graphql({ session });
+
+        const order = await getOrder(req.params.id, req.user.id);
+
+        if(!order) {
+            return res.status(403).send('You do not have permission to act on this order');
+        }
 
         const {before, after, first, last} = req.query;
 

--- a/web/fdc-modules/orders/controllers/get-order.js
+++ b/web/fdc-modules/orders/controllers/get-order.js
@@ -3,11 +3,18 @@ import getSession from '../../../utils/getShopifySession.js';
 import { createDfcOrderFromShopify } from '../dfc/dfc-order.js';
 import { findOrder } from './shopify/orders.js';
 import { getLineItems } from '../../../database/line_items/lineItems.js'
+import { getOrder as getOrderMetadata } from '../../../database/orders/orders.js';
 
 const getOrder = async (req, res) => {
     try {
         const session = await getSession(`${req.params.EnterpriseName}.myshopify.com`)
         const client = new shopify.api.clients.Graphql({ session });
+
+        const order = await getOrderMetadata(req.params.id, req.user.id);
+
+        if(!order) {
+            return res.status(403).send('You do not have permission to act on this order');
+        }
 
         const { order: shopifyOrder } = await findOrder(client, req.params.id, {});
 

--- a/web/fdc-modules/orders/controllers/shopify/orders.js
+++ b/web/fdc-modules/orders/controllers/shopify/orders.js
@@ -63,11 +63,11 @@ export async function findOrder(client, orderId, { first, last, after, before })
     };
 }
 
-export async function findOrders(client, { first, last, after, before }) {
+export async function findOrders(client, customerId, { first, last, after, before }) {
 
     const query = `
     query findDraftOrders($first: Int, $last: Int, $after: String, $before: String) {
-        draftOrders(first: $first, last: $last, after: $after, before: $before, query: "tag:fdc") {
+        draftOrders(first: $first, last: $last, after: $after, before: $before, query: "tag:fdc AND customer_id:${ids.extract(customerId)}") {
             nodes {
                 id    
                 status   

--- a/web/fdc-modules/orders/controllers/update-order.js
+++ b/web/fdc-modules/orders/controllers/update-order.js
@@ -5,17 +5,25 @@ import shopify from '../../../shopify.js';
 import getSession from '../../../utils/getShopifySession.js';
 import {
   createDfcOrderFromShopify,
-  extractOrderAndLines
+  extractOrderAndLines,
 } from '../dfc/dfc-order.js';
 import { persistLineIdMappings } from './lineItemMappings.js';
 import * as ids from './shopify/ids.js';
 import * as shopifyOrders from './shopify/orders.js';
 
-//todo: transaction
 const updateOrder = async (req, res) => {
   try {
     console.log('updating order with body:>> ', req.body);
     console.log('updating order with params :>> ', req.params);
+
+    const orderMetadata = await database.getOrder(req.params.id, req.user.id);
+
+    if (!orderMetadata) {
+      return res
+        .status(403)
+        .send('You do not have permission to act on this order');
+    }
+
     const session = await getSession(
       `${req.params.EnterpriseName}.myshopify.com`
     );


### PR DESCRIPTION
Record the user id against the order in the database when it is created

retrieve the order only when the keycloak user id corresponds to the user id on the order

When we retrieve all orders, we do this via graphql not our db. Add a query term to only bring back orders that correspond to the shopify customer corresponding to the keycloak user id