### PR TITLE
Fix: retry Shopify GraphQL calls on rate limit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@
 - **`package-lock.json` files** appear at root and `web/` after `yarn install` but are **not tracked** (`.gitignore` excludes them). Don't stage or commit them.
 - **Cherry-picking from staging:** Skip commits that revert the connector to an older ref (e.g. `jgaehring/connector-typescript#rc-alpha-12`). Regenerate lockfiles **on the target branch** with `yarn install` rather than trying to merge lockfile diffs.
 - **Engines field:** `web/package.json` `engines.node` on `main` may lag behind staging's `>=20.10.0`. After cherry-picks, verify it matches the actual runtime (Dockerfile uses Node 20).
+- **Rate limit retry:** `web/fdc-modules/orders/controllers/shopify/retryClient.js` wraps all Shopify GraphQL calls in `orders.js` with exponential backoff (3 retries, 1s→2s→4s + jitter). Detects `THROTTLED` in error extensions and catches thrown errors. If adding a new Shopify API call elsewhere, use `requestWithRetry(client, query, options)` instead of `client.request()`.
 
 ## Migration branch
 

--- a/web/fdc-modules/orders/controllers/shopify/orders.js
+++ b/web/fdc-modules/orders/controllers/shopify/orders.js
@@ -1,10 +1,11 @@
 import * as ids from './ids.js'
+import { requestWithRetry } from './retryClient.js'
 
 const PAY_ON_RECEIPT = "gid://shopify/PaymentTermsTemplate/1";
 
 export async function findOrder(client, orderId, { first, last, after, before }) {
     const firstToUse = first ? first : last ? null : 250;
-    const response = await client.request(`query MyQuery($id: ID!, $first: Int, $last: Int, $after: String, $before: String) {
+    const response = await requestWithRetry(client,`query MyQuery($id: ID!, $first: Int, $last: Int, $after: String, $before: String) {
         draftOrder(id: $id) {
             id
             status
@@ -108,7 +109,7 @@ export async function findOrders(client, customerId, { first, last, after, befor
 
     const firstToUse = first ? first : last ? null : 250;
 
-    const response = await client.request(query, {
+    const response = await requestWithRetry(client,query, {
         variables: { first: firstToUse, last, after, before }
     });
 
@@ -163,7 +164,7 @@ export async function createShopifyOrder(client, customerId, customerEmail, rese
         }
       }`;
 
-    const response = await client.request(query, {
+    const response = await requestWithRetry(client,query, {
         variables: {
             "input": {
                 "purchasingEntity": {
@@ -236,7 +237,7 @@ export async function updateOrder(client, orderId, reservationDate, lines) {
         }
       }`;
 
-    const response = await client.request(query, {
+    const response = await requestWithRetry(client,query, {
         variables: {
             "id": ids.draftOrder(orderId),
             "input": {
@@ -304,7 +305,7 @@ export async function completeDraftOrder(client, orderId) {
       }`;
 
 
-    const response = await client.request(query, {
+    const response = await requestWithRetry(client,query, {
         variables: {
             "id": ids.draftOrder(orderId)
         },

--- a/web/fdc-modules/orders/controllers/shopify/retryClient.js
+++ b/web/fdc-modules/orders/controllers/shopify/retryClient.js
@@ -1,0 +1,55 @@
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1000;
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isThrottled(response) {
+  if (!response) return false;
+  if (response.errors) {
+    return response.errors.some(
+      (err) =>
+        err.extensions?.code === 'THROTTLED' ||
+        err.message?.toLowerCase().includes('throttled'),
+    );
+  }
+  return false;
+}
+
+export async function requestWithRetry(client, query, options = {}) {
+  let lastError;
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const response = await client.request(query, options);
+
+      if (isThrottled(response)) {
+        if (attempt < MAX_RETRIES) {
+          const wait = BASE_DELAY_MS * 2 ** attempt + Math.random() * 500;
+          console.warn(
+            `Shopify rate limit hit, retrying in ${Math.round(wait)}ms (attempt ${attempt + 1}/${MAX_RETRIES})`,
+          );
+          await delay(wait);
+          continue;
+        }
+        throw new Error('Shopify rate limit exceeded after all retries');
+      }
+
+      return response;
+    } catch (err) {
+      if (attempt < MAX_RETRIES) {
+        const wait = BASE_DELAY_MS * 2 ** attempt + Math.random() * 500;
+        console.warn(
+          `Shopify request failed (${err.message}), retrying in ${Math.round(wait)}ms (attempt ${attempt + 1}/${MAX_RETRIES})`,
+        );
+        await delay(wait);
+        lastError = err;
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  throw lastError || new Error('Request failed after all retries');
+}

--- a/web/fdc-modules/orders/controllers/shopify/retryClient.js
+++ b/web/fdc-modules/orders/controllers/shopify/retryClient.js
@@ -5,16 +5,16 @@ function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function isThrottled(response) {
-  if (!response) return false;
-  if (response.errors) {
-    return response.errors.some(
-      (err) =>
-        err.extensions?.code === 'THROTTLED' ||
-        err.message?.toLowerCase().includes('throttled'),
-    );
-  }
-  return false;
+function isThrottled(responseOrError) {
+  if (!responseOrError) return false;
+  const errors = responseOrError.errors
+    || responseOrError.response?.errors
+    || [];
+  return errors.some(
+    (err) =>
+      err.extensions?.code === 'THROTTLED' ||
+      err.message?.toLowerCase().includes('throttled'),
+  );
 }
 
 export async function requestWithRetry(client, query, options = {}) {
@@ -38,6 +38,18 @@ export async function requestWithRetry(client, query, options = {}) {
 
       return response;
     } catch (err) {
+      if (isThrottled(err)) {
+        if (attempt < MAX_RETRIES) {
+          const wait = BASE_DELAY_MS * 2 ** attempt + Math.random() * 500;
+          console.warn(
+            `Shopify rate limit hit, retrying in ${Math.round(wait)}ms (attempt ${attempt + 1}/${MAX_RETRIES})`,
+          );
+          await delay(wait);
+          continue;
+        }
+        throw new Error('Shopify rate limit exceeded after all retries');
+      }
+
       if (attempt < MAX_RETRIES) {
         const wait = BASE_DELAY_MS * 2 ** attempt + Math.random() * 500;
         console.warn(
@@ -47,6 +59,7 @@ export async function requestWithRetry(client, query, options = {}) {
         lastError = err;
         continue;
       }
+
       throw err;
     }
   }

--- a/web/fdc-modules/orders/controllers/shopify/retryClient.spec.js
+++ b/web/fdc-modules/orders/controllers/shopify/retryClient.spec.js
@@ -1,0 +1,53 @@
+import { requestWithRetry } from './retryClient.js';
+
+function fakeClient(responseFactory) {
+  let callCount = 0;
+  return {
+    _callCount: () => callCount,
+    request: async () => {
+      callCount++;
+      return responseFactory(callCount);
+    },
+  };
+}
+
+describe('retryClient', () => {
+  it('returns response on first success', async () => {
+    const client = fakeClient(() => ({ data: { ok: true } }));
+    const result = await requestWithRetry(client, 'query { x }');
+    expect(result).toEqual({ data: { ok: true } });
+    expect(client._callCount()).toBe(1);
+  });
+
+  it('retries on throttled response then succeeds', async () => {
+    let client;
+    client = fakeClient((n) => {
+      if (n <= 2) return { errors: [{ extensions: { code: 'THROTTLED' } }] };
+      return { data: { ok: true } };
+    });
+    const result = await requestWithRetry(client, 'query { x }');
+    expect(result).toEqual({ data: { ok: true } });
+    expect(client._callCount()).toBe(3);
+  }, 15000);
+
+  it('throws after exhausting retries on throttled', async () => {
+    const client = fakeClient(() => ({
+      errors: [{ extensions: { code: 'THROTTLED' } }],
+    }));
+    await expect(
+      requestWithRetry(client, 'query { x }'),
+    ).rejects.toThrow('Shopify rate limit exceeded after all retries');
+    expect(client._callCount()).toBe(4);
+  }, 15000);
+
+  it('retries on thrown errors then succeeds', async () => {
+    let client;
+    client = fakeClient((n) => {
+      if (n <= 2) throw new Error('Network error');
+      return { data: { ok: true } };
+    });
+    const result = await requestWithRetry(client, 'query { x }');
+    expect(result).toEqual({ data: { ok: true } });
+    expect(client._callCount()).toBe(3);
+  }, 15000);
+});

--- a/web/fdc-modules/orders/controllers/shopify/retryClient.spec.js
+++ b/web/fdc-modules/orders/controllers/shopify/retryClient.spec.js
@@ -20,8 +20,7 @@ describe('retryClient', () => {
   });
 
   it('retries on throttled response then succeeds', async () => {
-    let client;
-    client = fakeClient((n) => {
+    const client = fakeClient((n) => {
       if (n <= 2) return { errors: [{ extensions: { code: 'THROTTLED' } }] };
       return { data: { ok: true } };
     });
@@ -38,11 +37,10 @@ describe('retryClient', () => {
       requestWithRetry(client, 'query { x }'),
     ).rejects.toThrow('Shopify rate limit exceeded after all retries');
     expect(client._callCount()).toBe(4);
-  }, 15000);
+  }, 30000);
 
   it('retries on thrown errors then succeeds', async () => {
-    let client;
-    client = fakeClient((n) => {
+    const client = fakeClient((n) => {
       if (n <= 2) throw new Error('Network error');
       return { data: { ok: true } };
     });


### PR DESCRIPTION
## Problem

Production issue: the `draftOrderComplete` mutation fails silently when Shopify's API rate limit is exceeded. The draft order is never converted to a full order.

## Solution

New `retryClient.js` wrapper around `client.request()` with exponential backoff:

- Detects `THROTTLED` in GraphQL error extensions
- Also catches thrown errors (network issues, timeouts)
- Retries up to 3 times with backoff: 1s → 2s → 4s (+ random jitter up to 500ms)
- Logs a warning on each retry
- Applies to all 5 GraphQL calls in `orders.js` (find, create, update, complete)

## Testing

```
✓ returns response on first success
✓ retries on throttled response then succeeds
✓ throws after exhausting retries on throttled
✓ retries on thrown errors then succeeds
```

## Next

After merge, the App Bridge v4 CDN migration can begin on `migrate/app-bridge-v4`.