### PR TITLE
fix(e2e): include MOCK_ADMIN_PORT in exit-iframe redirect target

### DIFF
--- a/e2e/exit-iframe.spec.js
+++ b/e2e/exit-iframe.spec.js
@@ -27,7 +27,7 @@ test('ExitIframe page renders spinner and redirects to matching host redirectUri
   await page.goto(`http://localhost:${MOCK_ADMIN_PORT}/`);
   await page.waitForSelector('#app-iframe', { timeout: 15000 });
 
-  const redirectTarget = 'http://localhost/redirect-test-done';
+  const redirectTarget = `http://localhost:${MOCK_ADMIN_PORT}/redirect-test-done`;
   await navigateIframeTo(page, '/exitIframe', { redirectUri: redirectTarget });
 
   await page.waitForURL('**/redirect-test-done', { timeout: 10000 });


### PR DESCRIPTION
The exit-iframe test was using a hardcoded redirect URL with port 80 (http://localhost/redirect-test-done) instead of using MOCK_ADMIN_PORT (3080). This caused ERR_CONNECTION_REFUSED in CI because nothing was listening on port 80.

Fix: Use the same MOCK_ADMIN_PORT variable already used for the initial page.goto() call.

Verified locally: all 6 E2E tests pass with Node v20.20.2.