### PR TITLE
ci: fail deploy on Jelastic redeploy rejection

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -67,10 +67,11 @@ jobs:
         #     push-to-registry: true
         - name: Redeploy containers
           run: |
-            sudo apt-get install curl -y
-            REDEPLOY_URL="https://app.jpc.infomaniak.com/1.0/environment/control/rest/redeploycontainersbygroup?envName=${{ inputs.jelastic_env }}&session=${{ secrets.jelastic_access_token }}&tag=${{ steps.meta.outputs.tags }}&nodeGroup=cp"
+            sudo apt-get install curl jq -y
+            REDEPLOY_TOKEN="${{ secrets.jelastic_access_token }}"
+            echo "::add-mask::$REDEPLOY_TOKEN"
+            REDEPLOY_URL="https://app.jpc.infomaniak.com/1.0/environment/control/rest/redeploycontainersbygroup?envName=${{ inputs.jelastic_env }}&session=$REDEPLOY_TOKEN&tag=${{ steps.meta.outputs.tags }}&nodeGroup=cp"
             RESPONSE=$(curl --fail --silent --show-error "$REDEPLOY_URL")
-            echo "$RESPONSE"
             RESULT=$(printf '%s' "$RESPONSE" | jq -r '.result // empty' 2>/dev/null || true)
             if [ -z "$RESULT" ] || [ "$RESULT" != "0" ]; then
               ERROR=$(printf '%s' "$RESPONSE" | jq -r '.error // empty' 2>/dev/null || true)

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -68,4 +68,13 @@ jobs:
         - name: Redeploy containers
           run: |
             sudo apt-get install curl -y
-            curl https://app.jpc.infomaniak.com/1.0/environment/control/rest/redeploycontainersbygroup?envName=${{inputs.jelastic_env}}\&session=${{secrets.jelastic_access_token}}\&tag=${{steps.meta.outputs.tags}}\&nodeGroup=cp
+            REDEPLOY_URL="https://app.jpc.infomaniak.com/1.0/environment/control/rest/redeploycontainersbygroup?envName=${{ inputs.jelastic_env }}&session=${{ secrets.jelastic_access_token }}&tag=${{ steps.meta.outputs.tags }}&nodeGroup=cp"
+            RESPONSE=$(curl --fail --silent --show-error "$REDEPLOY_URL")
+            echo "$RESPONSE"
+            RESULT=$(printf '%s' "$RESPONSE" | jq -r '.result // empty' 2>/dev/null || true)
+            if [ -z "$RESULT" ] || [ "$RESULT" != "0" ]; then
+              ERROR=$(printf '%s' "$RESPONSE" | jq -r '.error // empty' 2>/dev/null || true)
+              echo "::error::Jelastic redeploy rejected (result=${RESULT:-unknown}): ${ERROR:-no error message in response}"
+              exit 1
+            fi
+            echo "::notice::Jelastic redeploy accepted"


### PR DESCRIPTION
## Summary

The staging app has been silently stuck on the old image because the Jelastic redeploy step in `build-and-deploy.yml` reports **success even when Jelastic rejects the redeploy**.

The step ran `curl` without checking the response, and Jelastic returns HTTP 200 with a JSON error body for an invalid/expired access token:

```json
{"result":8201,"source":"JEL","error":"Token [...] is not valid or expired."}
```

Since `curl` exits 0 on HTTP 200, the workflow went green while staging kept serving the previous image.

## Change

- Quote the redeploy URL (replaces fragile `\\&` shell escaping)
- `curl --fail --silent --show-error` — HTTP-level failures now abort the step
- Parse the Jelastic JSON response and require `result == 0`; otherwise print the Jelastic `error` and `exit 1` so the run fails red
- Print a `::notice::` on success

Note: `--fail` alone would NOT catch this — the JSON `result` check is required.

Applies to both `deploy-staging.yml` and `deploy-main.yml` (they call this reusable workflow).

## Test plan

None (CI-only change). The next staging push will exercise it.