### PR TITLE
fix: let shopify-app-express read api secret from env

### DIFF
--- a/web/shopify.js
+++ b/web/shopify.js
@@ -41,7 +41,6 @@ const apiObject =
     : {
         apiVersion: LATEST_API_VERSION,
         billing: undefined,
-        apiSecretKey: config.SHOPIFY_API_SECRET_KEY,
         scopes
       };
 


### PR DESCRIPTION
## Summary

Fixes the staging 502 crash loop. The server was dying at boot with:

```
ShopifyError: Cannot initialize Shopify API Library. Missing values for: apiSecretKey
```

## Root cause

The app-bridge-v4 migration added `apiSecretKey` to the production `apiObject` in `web/shopify.js`, reading `config.SHOPIFY_API_SECRET_KEY` (i.e. `process.env.SHOPIFY_API_SECRET_KEY`). But the runtime env sets the variable as `SHOPIFY_API_SECRET` — the name `@shopify/shopify-app-express` itself reads internally (`apiSecretKey: process.env.SHOPIFY_API_SECRET`). The mismatch produced `undefined`, and v5 of `@shopify/shopify-api` validates `apiSecretKey` as mandatory at construction, throwing before the server could listen.

The pre-migration code did not pass `apiSecretKey` in production, so the library fell back to `process.env.SHOPIFY_API_SECRET` and worked.

## Change

Remove `apiSecretKey` from the production branch of `apiObject` (`web/shopify.js`), restoring the library's env-var fallback. The dev branch is untouched (it still passes `config.SHOPIFY_API_SECRET_KEY` + `config.HOST`).

## Related

- Requires `PORT=8081` set in the Jelastic env (done) to match the Dockerfile's `EXPOSE 8081`.
- Follow-up hardening: `build-and-deploy.yml` redeploy step now fails loudly on Jelastic rejection (PR #105), and we should align the env-var name (`SHOPIFY_API_SECRET` vs `SHOPIFY_API_SECRET_KEY`) across `web/config.js` + Jelastic.