### PR TITLE
fix(e2e): set SHOPIFY_API_SECRET in webServer env

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -34,7 +34,7 @@ module.exports = defineConfig({
         MOCK_BRIDGE: '1',
         NODE_ENV: 'production',
         SHOPIFY_API_KEY: 'test-mock-key',
-        SHOPIFY_API_SECRET_KEY: 'test-mock-secret',
+        SHOPIFY_API_SECRET: 'test-mock-secret',
         HOST: `http://localhost:${BACKEND_PORT}`,
         DATABASE_HOST_URL: 'postgresql://mock:5432',
         SHOP_REGISTRY_DATABASE_NAME: 'mock',


### PR DESCRIPTION
PR #106 removed the explicit `apiSecretKey` from the production config so @shopify/shopify-app-express falls back to `process.env.SHOPIFY_API_SECRET`. But the Playwright webServer env set `SHOPIFY_API_SECRET_KEY` (which the library ignores), so the CI frontend-test crashed at boot:

```
ShopifyError: Cannot initialize Shopify API Library. Missing values for: apiSecretKey
```

Set `SHOPIFY_API_SECRET` (the env var the library actually reads) in `playwright.config.js`. Verified locally: webServer boots cleanly with these env vars.