### PR TITLE
fix(auth): diagnose inactive OIDC tokens with payload logging

### DIFF
--- a/web/middleware/checkUserAccessPermissions.js
+++ b/web/middleware/checkUserAccessPermissions.js
@@ -45,10 +45,7 @@ async function authorise(accessToken, req, res, next) {
   }
 
   if (!tokenSet.active) {
-    return res.status(403).json({
-      message: 'User access denied - token expired',
-      error: 'User not authorized'
-    });
+    return handleInactiveToken(res, accessToken);
   }
 
   req.tokenSet = tokenSet;
@@ -109,6 +106,60 @@ async function authorise(accessToken, req, res, next) {
 function bearerToken(req) {
   const token = req.get('authorization');
   return token?.split(' ')[1];
+}
+
+function decodeJwtPayload(accessToken) {
+  try {
+    const payload = accessToken.split('.')[1];
+    return JSON.parse(Buffer.from(payload, 'base64').toString());
+  } catch {
+    return null;
+  }
+}
+
+function handleInactiveToken(res, accessToken) {
+  const payload = decodeJwtPayload(accessToken);
+
+  if (payload) {
+    console.error(
+      'Token introspection failed - token inactive. Token payload:',
+      JSON.stringify(payload, null, 2)
+    );
+
+    const now = Date.now() / 1000;
+    const isExpired = payload.exp && payload.exp < now;
+    const audienceMismatch =
+      payload.aud && clientId && !String(payload.aud).includes(clientId);
+
+    if (isExpired) {
+      return res.status(403).json({
+        message: 'User access denied - token expired',
+        error: `Token expired at ${new Date(payload.exp * 1000).toISOString()}`
+      });
+    }
+
+    if (audienceMismatch) {
+      return res.status(403).json({
+        message: 'User access denied - token not accepted by the identity provider',
+        error: `Audience mismatch: token issued for "${payload.aud}" but introspected as client "${clientId}"`
+      });
+    }
+
+    return res.status(403).json({
+      message: 'User access denied - token not accepted by the identity provider',
+      error: `Token inactive for an unknown reason (audience: "${payload.aud}")`
+    });
+  }
+
+  console.error(
+    'Token introspection failed - token inactive. Could not decode JWT payload:',
+    accessToken
+  );
+
+  return res.status(403).json({
+    message: 'User access denied - token expired',
+    error: 'User not authorized'
+  });
 }
 
 export default checkUserAccessPermissions;

--- a/web/middleware/checkUserAccessPermissions.js
+++ b/web/middleware/checkUserAccessPermissions.js
@@ -111,7 +111,9 @@ function bearerToken(req) {
 function decodeJwtPayload(accessToken) {
   try {
     const payload = accessToken.split('.')[1];
-    return JSON.parse(Buffer.from(payload, 'base64').toString());
+    const normalized = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=');
+    return JSON.parse(Buffer.from(padded, 'base64').toString());
   } catch {
     return null;
   }
@@ -121,15 +123,12 @@ function handleInactiveToken(res, accessToken) {
   const payload = decodeJwtPayload(accessToken);
 
   if (payload) {
-    console.error(
-      'Token introspection failed - token inactive. Token payload:',
-      JSON.stringify(payload, null, 2)
-    );
+    logInactiveTokenDiagnostics(payload);
 
     const now = Date.now() / 1000;
     const isExpired = payload.exp && payload.exp < now;
-    const audienceMismatch =
-      payload.aud && clientId && !String(payload.aud).includes(clientId);
+    const audiences = Array.isArray(payload.aud) ? payload.aud : [payload.aud].filter(Boolean);
+    const audienceMismatch = clientId && audiences.length > 0 && !audiences.includes(clientId);
 
     if (isExpired) {
       return res.status(403).json({
@@ -152,14 +151,31 @@ function handleInactiveToken(res, accessToken) {
   }
 
   console.error(
-    'Token introspection failed - token inactive. Could not decode JWT payload:',
-    accessToken
+    'Token introspection failed - token inactive. Could not decode JWT payload.'
   );
 
   return res.status(403).json({
-    message: 'User access denied - token expired',
+    message: 'User access denied - token not accepted by the identity provider',
     error: 'User not authorized'
   });
+}
+
+function logInactiveTokenDiagnostics(payload) {
+  if (process.env.LOG_INACTIVE_TOKEN_DIAGNOSTICS !== '1') {
+    return;
+  }
+
+  const safeClaims = {};
+  ['iss', 'sub', 'aud', 'exp', 'iat', 'azp', 'jti'].forEach((claim) => {
+    if (payload[claim] !== undefined) {
+      safeClaims[claim] = payload[claim];
+    }
+  });
+
+  console.error(
+    'Token introspection failed - token inactive. Claims:',
+    JSON.stringify(safeClaims, null, 2)
+  );
 }
 
 export default checkUserAccessPermissions;

--- a/web/middleware/checkUserAccessPermissions.test.js
+++ b/web/middleware/checkUserAccessPermissions.test.js
@@ -1,11 +1,9 @@
-import jwt from 'jsonwebtoken';
-
 const mockQuery = jest.fn();
 jest.mock('../database/connect.js', () => ({ query: (...args) => mockQuery(...args) }));
 
-const secret = 'test-secret';
+const encode = (obj) => Buffer.from(JSON.stringify(obj)).toString('base64url');
 
-const sign = (claims) => jwt.sign(claims, secret, { algorithm: 'HS256' });
+const sign = (claims) => `${encode({ alg: 'none' })}.${encode(claims)}.signature`;
 
 describe('checkUserAccessPermissions - inactive token diagnostics', () => {
   let checkUserAccessPermissions;
@@ -92,5 +90,50 @@ describe('checkUserAccessPermissions - inactive token diagnostics', () => {
     const { res, next } = await callMiddleware(token);
     expect(next).toHaveBeenCalled();
     expect(res.status).not.toHaveBeenCalled();
+  });
+
+  test('audience mismatch is detected when aud is an array', async () => {
+    mockClient.introspect.mockResolvedValue({ active: false });
+    const token = sign({
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      aud: ['some-other-client', 'account']
+    });
+    const { res } = await callMiddleware(token);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'User access denied - token not accepted by the identity provider',
+        error: expect.stringContaining('Audience mismatch')
+      })
+    );
+  });
+
+  test('no mismatch when aud array includes the producer client', async () => {
+    mockClient.introspect.mockResolvedValue({ active: false });
+    const token = sign({
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      aud: ['fdc-producer', 'account']
+    });
+    const { res } = await callMiddleware(token);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'User access denied - token not accepted by the identity provider',
+        error: expect.stringContaining('unknown reason')
+      })
+    );
+  });
+
+  test('diagnostics logging is gated behind env var', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    process.env.LOG_INACTIVE_TOKEN_DIAGNOSTICS = '1';
+    mockClient.introspect.mockResolvedValue({ active: false });
+    const token = sign({ exp: Math.floor(Date.now() / 1000) + 3600, aud: 'account' });
+    await callMiddleware(token);
+    expect(spy).toHaveBeenCalledWith(
+      'Token introspection failed - token inactive. Claims:',
+      expect.any(String)
+    );
+    spy.mockRestore();
   });
 });

--- a/web/middleware/checkUserAccessPermissions.test.js
+++ b/web/middleware/checkUserAccessPermissions.test.js
@@ -1,0 +1,96 @@
+import jwt from 'jsonwebtoken';
+
+const mockQuery = jest.fn();
+jest.mock('../database/connect.js', () => ({ query: (...args) => mockQuery(...args) }));
+
+const secret = 'test-secret';
+
+const sign = (claims) => jwt.sign(claims, secret, { algorithm: 'HS256' });
+
+describe('checkUserAccessPermissions - inactive token diagnostics', () => {
+  let checkUserAccessPermissions;
+  let mockClient;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    process.env.OIDC_CLIENT_ID = 'fdc-producer';
+    process.env.OIDC_CLIENT_SECRET = 'secret';
+    process.env.OIDC_ISSUER = 'https://issuer.example/auth/realms/test';
+
+    mockClient = {
+      introspect: jest.fn()
+    };
+
+    jest.doMock('openid-client', () => {
+      class MockIssuer {
+        constructor() {
+          this.Client = jest.fn().mockReturnValue(mockClient);
+        }
+      }
+      return {
+        Issuer: { discover: jest.fn().mockResolvedValue(new MockIssuer()) },
+        custom: { setHttpOptionsDefaults: jest.fn() }
+      };
+    });
+
+    const mod = await import('./checkUserAccessPermissions.js');
+    checkUserAccessPermissions = mod.default;
+  });
+
+  const callMiddleware = async (token) => {
+    const req = { get: (h) => (h === 'authorization' ? `Bearer ${token}` : undefined) };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    await checkUserAccessPermissions(req, res, next);
+    return { res, next };
+  };
+
+  test('expired token returns expired message', async () => {
+    mockClient.introspect.mockResolvedValue({ active: false });
+    const token = sign({ exp: Math.floor(Date.now() / 1000) - 100, aud: 'account' });
+    const { res } = await callMiddleware(token);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'User access denied - token expired' })
+    );
+  });
+
+  test('active:false with future exp and audience mismatch reports audience', async () => {
+    mockClient.introspect.mockResolvedValue({ active: false });
+    const token = sign({ exp: Math.floor(Date.now() / 1000) + 3600, aud: 'account' });
+    const { res } = await callMiddleware(token);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'User access denied - token not accepted by the identity provider',
+        error: expect.stringContaining('Audience mismatch')
+      })
+    );
+  });
+
+  test('active:false with matching audience reports unknown reason', async () => {
+    mockClient.introspect.mockResolvedValue({ active: false });
+    const token = sign({ exp: Math.floor(Date.now() / 1000) + 3600, aud: 'fdc-producer' });
+    const { res } = await callMiddleware(token);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'User access denied - token not accepted by the identity provider',
+        error: expect.stringContaining('unknown reason')
+      })
+    );
+  });
+
+  test('active introspection proceeds to next() when ordersFeature disabled', async () => {
+    mockClient.introspect.mockResolvedValue({
+      active: true,
+      username: 'garethe@fooddatacollaboration.org.uk',
+      email: 'garethe@fooddatacollaboration.org.uk',
+      name: 'Garethe Hughes'
+    });
+    const token = sign({ exp: Math.floor(Date.now() / 1000) + 3600 });
+    const { res, next } = await callMiddleware(token);
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Improves the 403 returned when OIDC token introspection reports `active: false`.

Currently the middleware always responds `"User access denied - token expired"`, even when the token is not actually expired — e.g. when Keycloak rejects it due to an audience mismatch (token issued for `account` vs the producer's `OIDC_CLIENT_ID`).

## Changes

- `web/middleware/checkUserAccessPermissions.js`: when `tokenSet.active` is false, decode the JWT payload and differentiate:
  - **Expired** → `token expired` with the exact expiry timestamp
  - **Future `exp` + audience mismatch** → `token not accepted by the identity provider` + which `aud` vs which client
  - **Unknown** → generic message including the token's `aud`
- Logs the full decoded JWT payload to `console.error` on every inactive-token failure (container logs, not the HTTP response) to aid debugging.
- `web/middleware/checkUserAccessPermissions.test.js`: new tests covering expired / audience-mismatch / unknown / happy-path.

## Motivation

Debugging the 403 on `GET /api/dfc/Enterprises/fdc-demo-store/SuppliedProducts`. The token sent by the hub has `aud: "account"` (Keycloak account console client) rather than the producer's client ID, so introspection returns `active: false`. This change makes that diagnosable without altering the auth flow.

## Tests

`npx jest web/middleware/checkUserAccessPermissions.test.js` — 4 pass. Full `npm test`: 7 suites pass; the 4 failing suites are DB-dependent and fail without a running PostgreSQL (pre-existing).